### PR TITLE
Export type definitions

### DIFF
--- a/src/FlashlessScript.tsx
+++ b/src/FlashlessScript.tsx
@@ -3,6 +3,8 @@ import {Dict} from '@chakra-ui/utils';
 import {getColor, transparentize} from '@chakra-ui/theme-tools';
 import {outdent} from 'outdent';
 
+import {Color, Variables} from './types';
+
 const baseVariables = {
   '--bg': ['white', 'gray.800'],
   '--text': ['gray.800', 'whiteAlpha.900'],
@@ -10,9 +12,6 @@ const baseVariables = {
   '--border': ['gray.200', 'whiteAlpha.300'],
   '--badge-text': ['white', 'whiteAlpha.800']
 };
-
-type Color = string | [string, number];
-type Variables = Record<string, [Color, Color]>;
 
 function createVariables(theme: Dict, customVariables?: Variables): string {
   function colorValue(color: Color) {

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,2 +1,5 @@
+import * as Types from './types';
 export * from './FlashlessScript';
 export * from './flashless';
+
+export {Types};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,2 @@
+export type Color = string | [string, number];
+export type Variables = Record<string, [Color, Color]>;


### PR DESCRIPTION
This PR implement changes to explicitly export type definitions.

The following error occurs when declaring an object with color variables in a separate module, instead of defining inline.

![image](https://user-images.githubusercontent.com/48022589/109429800-b5839e80-79dc-11eb-99ed-5d3e23d41679.png)

In order to type the object, the package should export the respective type, like so:

```js
import { Types } from 'chakra-ui-flashless'

export const colorModeVariables: Types.Variables = { ... }
```