### PR TITLE
Initialize color mode based on color scheme 

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@laurabeatris/chakra-ui-flashless",
-  "version": "0.1.10",
+  "version": "0.2.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@laurabeatris/chakra-ui-flashless",
-  "version": "0.1.10",
+  "version": "0.2.11",
   "description": "Tools to implement flashless color modes in Chakra UI",
   "author": "Trevor Blades <tdblades@gmail.com>",
   "repository": "trevorblades/chakra-ui-flashless",
@@ -22,7 +22,7 @@
     "build": "rollup -c",
     "pretest": "eslint src/*",
     "test": "exit",
-    "prepare": "build"
+    "prepare": "npm run build"
   },
   "devDependencies": {
     "@chakra-ui/react": "^1.1.6",

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -12,7 +12,7 @@ import {createDefaultVariables, getColorValue} from './helpers';
 
 const ColorModeContext = createContext({} as ColorModeContextValue);
 
-export function ColorModeToggle({
+export function ColorModeToggleProvider({
   theme,
   children,
   customVariables,

--- a/src/ColorModeToggle.tsx
+++ b/src/ColorModeToggle.tsx
@@ -9,6 +9,7 @@ import React, {
 
 import {ColorModeContextValue, ColorModeToggleProps} from './types';
 import {createDefaultVariables, getColorValue} from './helpers';
+import {usePrefersColorScheme} from './hooks/usePrefersColorScheme';
 
 const ColorModeContext = createContext({} as ColorModeContextValue);
 
@@ -19,6 +20,18 @@ export function ColorModeToggleProvider({
   initialColorMode
 }: ColorModeToggleProps): JSX.Element {
   const [colorMode, setColorMode] = useState(initialColorMode);
+  const {prefersColorScheme, hasMounted} = usePrefersColorScheme();
+
+  useEffect(() => {
+    const shouldUsePrefersColorScheme =
+      !hasMounted && !initialColorMode && prefersColorScheme;
+
+    if (!shouldUsePrefersColorScheme) {
+      return;
+    }
+
+    setColorMode(prefersColorScheme);
+  }, [hasMounted, initialColorMode, prefersColorScheme]);
 
   const defaultVariables = useMemo(() => createDefaultVariables(theme), [
     theme

--- a/src/components/FlashlessScript.tsx
+++ b/src/components/FlashlessScript.tsx
@@ -3,7 +3,7 @@ import {Dict} from '@chakra-ui/utils';
 import {getColor, transparentize} from '@chakra-ui/theme-tools';
 import {outdent} from 'outdent';
 
-import {Color, Variables} from './types';
+import {Color, Variables} from '../types';
 
 const baseVariables = {
   '--bg': ['white', 'gray.800'],

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -1,4 +1,4 @@
-import {Color, Variables} from './types';
+import {Color, ToggleColorVariablesParameters, Variables} from './types';
 import {Dict} from '@chakra-ui/utils';
 import {getColor, transparentize} from '@chakra-ui/theme-tools';
 
@@ -47,4 +47,30 @@ export function getColorValue(theme: Dict, color: Color): string {
   return Array.isArray(color)
     ? transparentize(...color)(theme)
     : getColor(theme, color);
+}
+
+export function toggleColorVariables({
+  theme,
+  colorMode,
+  customVariables
+}: ToggleColorVariablesParameters): void {
+  const defaultVariables = createDefaultVariables(theme);
+
+  const root = window.document.documentElement;
+
+  const isDarkMode = colorMode === 'dark';
+
+  Object.entries({
+    ...defaultVariables,
+    ...customVariables
+  }).forEach(([name, values]) =>
+    root.style.setProperty(
+      name,
+      isDarkMode
+        ? `${getColorValue(theme, values[1])}`
+        : `${getColorValue(theme, values[0])}`
+    )
+  );
+
+  root.style.setProperty('--chakra-ui-color-mode', colorMode);
 }

--- a/src/hooks/useHasMounted/index.ts
+++ b/src/hooks/useHasMounted/index.ts
@@ -1,0 +1,19 @@
+import {useEffect, useState} from 'react';
+
+/**
+ * Handles the mounted state of the component.
+ *
+ * Useful for cases where a content should only be rendered on the browser
+ * and the DOM should stay the same on the server and on the re-hydration process.
+ */
+export function useHasMounted(): boolean {
+  const [hasMounted, setHasMounted] = useState(false);
+
+  useEffect(() => {
+    setHasMounted(true);
+  }, []);
+
+  return hasMounted;
+}
+
+export default useHasMounted;

--- a/src/hooks/usePrefersColorScheme/index.ts
+++ b/src/hooks/usePrefersColorScheme/index.ts
@@ -4,6 +4,12 @@ import {useHasMounted} from '../useHasMounted';
 
 import {UsePrefersColorSchemePayload} from './types';
 
+function getNewColorScheme(event: MediaQueryList): string {
+  const newColorScheme = event.matches ? 'dark' : 'light';
+
+  return newColorScheme;
+}
+
 /**
  * Gets the color scheme preferred by the user and listen to it's change
  */
@@ -19,9 +25,34 @@ export function usePrefersColorScheme(): UsePrefersColorSchemePayload {
     const prefersColorScheme = window.matchMedia(
       '(prefers-color-scheme: dark)'
     );
-    const newColorScheme = prefersColorScheme.matches ? 'dark' : 'light';
 
-    setPrefersColorScheme(newColorScheme);
+    setPrefersColorScheme(getNewColorScheme(prefersColorScheme));
+  }, [hasMounted]);
+
+  useEffect(() => {
+    if (!hasMounted) {
+      return;
+    }
+
+    function changeListenerPrefersColorScheme(event) {
+      setPrefersColorScheme(getNewColorScheme(event));
+    }
+
+    const prefersColorScheme = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    );
+
+    prefersColorScheme.addEventListener(
+      'change',
+      changeListenerPrefersColorScheme
+    );
+
+    return function removeListenerPrefersColorScheme() {
+      prefersColorScheme.removeEventListener(
+        'change',
+        changeListenerPrefersColorScheme
+      );
+    };
   }, [hasMounted]);
 
   return {prefersColorScheme, hasMounted};

--- a/src/hooks/usePrefersColorScheme/index.ts
+++ b/src/hooks/usePrefersColorScheme/index.ts
@@ -1,4 +1,4 @@
-import {useCallback, useEffect, useState} from 'react';
+import {useEffect, useState} from 'react';
 
 import {useHasMounted} from '../useHasMounted';
 
@@ -11,26 +11,18 @@ export function usePrefersColorScheme(): UsePrefersColorSchemePayload {
   const hasMounted = useHasMounted();
   const [prefersColorScheme, setPrefersColorScheme] = useState(null);
 
-  const getPrefersColorScheme = useCallback(prefersColorScheme => {
-    const newColorScheme = prefersColorScheme.matches ? 'dark' : 'light';
-
-    setPrefersColorScheme(newColorScheme);
-  }, []);
-
   useEffect(() => {
     if (!hasMounted) {
       return;
     }
 
-    window
-      .matchMedia('(prefers-color-scheme: dark)')
-      .addEventListener('change', getPrefersColorScheme);
+    const prefersColorScheme = window.matchMedia(
+      '(prefers-color-scheme: dark)'
+    );
+    const newColorScheme = prefersColorScheme.matches ? 'dark' : 'light';
 
-    return () =>
-      window
-        .matchMedia('(prefers-color-scheme: dark)')
-        .removeEventListener('change', getPrefersColorScheme);
-  }, [getPrefersColorScheme, hasMounted]);
+    setPrefersColorScheme(newColorScheme);
+  }, [hasMounted]);
 
   return {prefersColorScheme, hasMounted};
 }

--- a/src/hooks/usePrefersColorScheme/index.ts
+++ b/src/hooks/usePrefersColorScheme/index.ts
@@ -1,0 +1,36 @@
+import {useCallback, useEffect, useState} from 'react';
+
+import {useHasMounted} from '../useHasMounted';
+
+import {UsePrefersColorSchemePayload} from './types';
+
+/**
+ * Gets the color scheme preferred by the user and listen to it's change
+ */
+export function usePrefersColorScheme(): UsePrefersColorSchemePayload {
+  const hasMounted = useHasMounted();
+  const [prefersColorScheme, setPrefersColorScheme] = useState(null);
+
+  const getPrefersColorScheme = useCallback(prefersColorScheme => {
+    const newColorScheme = prefersColorScheme.matches ? 'dark' : 'light';
+
+    setPrefersColorScheme(newColorScheme);
+  }, []);
+
+  useEffect(() => {
+    if (!hasMounted) {
+      return;
+    }
+
+    window
+      .matchMedia('(prefers-color-scheme: dark)')
+      .addEventListener('change', getPrefersColorScheme);
+
+    return () =>
+      window
+        .matchMedia('(prefers-color-scheme: dark)')
+        .removeEventListener('change', getPrefersColorScheme);
+  }, [getPrefersColorScheme, hasMounted]);
+
+  return {prefersColorScheme, hasMounted};
+}

--- a/src/hooks/usePrefersColorScheme/types.ts
+++ b/src/hooks/usePrefersColorScheme/types.ts
@@ -1,0 +1,6 @@
+import {ColorMode} from '@chakra-ui/color-mode';
+
+export type UsePrefersColorSchemePayload = {
+  hasMounted: boolean;
+  prefersColorScheme: ColorMode;
+};

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,6 +1,6 @@
-import * as Types from './types';
-export * from './FlashlessScript';
+export * from './components/FlashlessScript';
+export * from './providers/ColorModeToggleProvider';
 export * from './flashless';
-export * from './ColorModeToggle';
+import * as Types from './types';
 
 export {Types};

--- a/src/providers/ColorModeToggleProvider.tsx
+++ b/src/providers/ColorModeToggleProvider.tsx
@@ -7,9 +7,9 @@ import React, {
   useState
 } from 'react';
 
-import {ColorModeContextValue, ColorModeToggleProps} from './types';
-import {createDefaultVariables, getColorValue} from './helpers';
-import {usePrefersColorScheme} from './hooks/usePrefersColorScheme';
+import {ColorModeContextValue, ColorModeToggleProps} from '../types';
+import {createDefaultVariables, getColorValue} from '../helpers';
+import {usePrefersColorScheme} from '../hooks/usePrefersColorScheme';
 
 const ColorModeContext = createContext({} as ColorModeContextValue);
 
@@ -24,7 +24,7 @@ export function ColorModeToggleProvider({
 
   useEffect(() => {
     const shouldUsePrefersColorScheme =
-      !hasMounted && !initialColorMode && prefersColorScheme;
+      hasMounted && !initialColorMode && prefersColorScheme;
 
     if (!shouldUsePrefersColorScheme) {
       return;

--- a/src/providers/ColorModeToggleProvider.tsx
+++ b/src/providers/ColorModeToggleProvider.tsx
@@ -8,7 +8,11 @@ import React, {
 } from 'react';
 
 import {ColorModeContextValue, ColorModeToggleProps} from '../types';
-import {createDefaultVariables, getColorValue} from '../helpers';
+import {
+  createDefaultVariables,
+  getColorValue,
+  toggleColorVariables
+} from '../helpers';
 import {usePrefersColorScheme} from '../hooks/usePrefersColorScheme';
 
 const ColorModeContext = createContext({} as ColorModeContextValue);
@@ -22,6 +26,14 @@ export function ColorModeToggleProvider({
   const [colorMode, setColorMode] = useState(initialColorMode);
   const {prefersColorScheme, hasMounted} = usePrefersColorScheme();
 
+  const toggleColorMode = useCallback(() => {
+    setColorMode(prev => {
+      const newColorMode = prev === 'dark' ? 'light' : 'dark';
+
+      return newColorMode;
+    });
+  }, [colorMode, prefersColorScheme]);
+
   useEffect(() => {
     const shouldUsePrefersColorScheme =
       hasMounted && !initialColorMode && prefersColorScheme;
@@ -33,34 +45,13 @@ export function ColorModeToggleProvider({
     setColorMode(prefersColorScheme);
   }, [hasMounted, initialColorMode, prefersColorScheme]);
 
-  const defaultVariables = useMemo(() => createDefaultVariables(theme), [
-    theme
-  ]);
+  useEffect(() => {
+    if (!colorMode) {
+      return;
+    }
 
-  const toggleColorMode = useCallback(() => {
-    const root = window.document.documentElement;
-
-    setColorMode(prev => {
-      const newColorMode = prev === 'dark' ? 'light' : 'dark';
-      const isDarkMode = newColorMode === 'dark';
-
-      Object.entries({
-        ...defaultVariables,
-        ...customVariables
-      }).forEach(([name, values]) =>
-        root.style.setProperty(
-          name,
-          isDarkMode
-            ? `${getColorValue(theme, values[1])}`
-            : `${getColorValue(theme, values[0])}`
-        )
-      );
-
-      root.style.setProperty('--chakra-ui-color-mode', newColorMode);
-
-      return newColorMode;
-    });
-  }, [colorMode]);
+    toggleColorVariables({theme, colorMode, customVariables});
+  }, [theme, customVariables, colorMode]);
 
   const payload = useMemo(
     () => ({

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,7 +7,7 @@ export type Variables = Record<string, [Color, Color]>;
 export type ColorModeToggleProps = PropsWithChildren<{
   theme: Dict;
   customVariables: Variables;
-  initialColorMode: ColorMode;
+  initialColorMode?: ColorMode;
 }>;
 export type ColorModeContextValue = {
   colorMode: ColorMode;

--- a/src/types.ts
+++ b/src/types.ts
@@ -13,3 +13,8 @@ export type ColorModeContextValue = {
   colorMode: ColorMode;
   toggleColorMode: () => void;
 };
+export type ToggleColorVariablesParameters = {
+  theme: Dict;
+  colorMode: ColorMode;
+  customVariables: Variables;
+};


### PR DESCRIPTION
## Description 

Initialize color mode based on the color scheme. It handles hydration and listens for color scheme changes.

## How to test it

- Change your system color mode preferences and verify if the `colorMode` initial value changes 